### PR TITLE
Add Abilities and Slots to match NLU

### DIFF
--- a/bot/src/helpers/nlp.ts
+++ b/bot/src/helpers/nlp.ts
@@ -24,22 +24,22 @@ const nlpAdapter = (result: NlpObject): NlpResult[] => {
   if (result.tokens && result.tokens.items) {
     const nlpResult: NlpResult[] = intents.map(intent => {
       const filteredItems = result.tokens.items.filter(item => {
-        item.start >= intent.start && 
-        item.end <= intent.end
+        return item.start >= intent.start &&
+          item.end <= intent.end
       })
 
       const entities = filteredItems.map(item => {
         return {
           name: item.label,
-          value: result.utterance.slice[item.start, item.end],
-          text: result.utterance.slice[item.start, item.end],
+          value: result.utterance.slice(item.start, item.end).trim(),
+          text: result.utterance.slice(item.start, item.end).trim(),
         }
       })
       return {
         message: result.utterance,
         intent: intent.label,
         entities: entities
-      } 
+      }
     })
     return nlpResult
   }
@@ -52,7 +52,7 @@ const nlpAdapter = (result: NlpObject): NlpResult[] => {
  * @param context Botbuilder object containing user utterance
  */
 export const callNlu = (context: TurnContext): Promise<wolf.NlpResult[]> => {
-  return fetch(`http://nlu:8080/${context.activity.text}`)
+  return fetch(`${process.env.NLU_ENDPOINT || "http://nlu:8080/"}${context.activity.text}`)
     .then((res) => res.json())
     .then((res) => nlpAdapter(res))
 }

--- a/bot/src/slots.ts
+++ b/bot/src/slots.ts
@@ -1,9 +1,30 @@
+// Import Wolf dependency
+import { Slot } from 'wolf-core'
+
+// Import Wolf's Bot Builder storage layer
+import { StorageLayerType } from 'wolf-botbuilder'
+
+// Import OrderState from abilities
+import { OrderState } from './abilities'
+
 // tokens (aka slot names): ADD SUBSTITUTE SIZE FLAVOR QUANTITY TARGET ITEM END_OF_ORDER NEED_MORE_TIME None
 // entities to focus on, tokens (aka slot names): ADD SUBSTITUTE SIZE FLAVOR TARGET ITEM END_OF_ORDER
 
 export const slots = [
   {
-    name: 'product',
-    query: () => { return 'What is the name of your product?' }
+    name: 'ITEM',
+    query: () => { return 'What item would you like?' }
   },
-] // as Slot<StorageLayerType<OrderState>>[]
+  {
+    name: 'QUANTITY',
+    query: () => { return 'How many items would you like?' }
+  },
+  {
+    name: 'TARGET',
+    query: () => { return 'What item would you like to target?' }
+  },
+  {
+    name: 'END_OF_ORDER',
+    query: () => { return 'Are you done with your order?' }
+  },
+] as Slot<StorageLayerType<OrderState>>[]


### PR DESCRIPTION
Added base Abilities: ADD, REMOVE, SUBSTITUTE, None
Added base Slots to match: ITEM, QUANTITY, TARGET, END_OF_ORDER
Made bot work with simple 'cart' that only tracks items, not quantities
Fixed nlpAdapter to correctly parse the NlpObject returned from NLU